### PR TITLE
convert to es5 before publishing to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ npm-debug.log
 
 docs/bundle.js
 docs/bundle.min.js
+dist
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -24,16 +24,16 @@
     "virtual-hyperscript-svg": "^2.0.0"
   },
   "devDependencies": {
+    "babelify": "^7.3.0",
     "babel-cli": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
-    "babelify": "^7.3.0",
     "browserify": "^14.3.0",
-    "uglify-es": "^3.0.24",
+    "uglify-js": "mishoo/UglifyJS2#harmony",
     "virtual-dom": "^2.1.1",
     "virtual-dom-stringify": "^3.0.1"
   },
   "scripts": {
-    "bundle": "browserify -t [ babelify --presets es2015 ] --no-bundle-external --entry ./index.js > es5.js && browserify -t [ babelify --presets es2015 ] docs/index.js > docs/bundle.js",
+    "bundle": "browserify -t [ babelify --presets es2015 ] docs/index.js > docs/bundle.js",
     "minify": "uglifyjs -mc --screw-ie8 -- docs/bundle.js > docs/bundle.min.js",
     "prepublish": "babel index.js --presets babel-preset-es2015 --out-dir dist",
     "build": "npm run bundle && npm run minify"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/juliuste/parliament-svg",
   "repository": "juliuste/parliament-svg",
   "bugs": "https://github.com/juliuste/parliament-svg/issues",
-  "main": "./index.js",
+  "main": "./dist/index.js",
   "files": [
     "index.js"
   ],
@@ -24,16 +24,18 @@
     "virtual-hyperscript-svg": "^2.0.0"
   },
   "devDependencies": {
-    "babelify": "^7.3.0",
+    "babel-cli": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
+    "babelify": "^7.3.0",
     "browserify": "^14.3.0",
-    "uglify-js": "mishoo/UglifyJS2#harmony",
+    "uglify-es": "^3.0.24",
     "virtual-dom": "^2.1.1",
     "virtual-dom-stringify": "^3.0.1"
   },
   "scripts": {
-    "bundle": "browserify -t [ babelify --presets es2015 ] docs/index.js > docs/bundle.js",
+    "bundle": "browserify -t [ babelify --presets es2015 ] --no-bundle-external --entry ./index.js > es5.js && browserify -t [ babelify --presets es2015 ] docs/index.js > docs/bundle.js",
     "minify": "uglifyjs -mc --screw-ie8 -- docs/bundle.js > docs/bundle.min.js",
+    "prepublish": "babel index.js --presets babel-preset-es2015 --out-dir dist",
     "build": "npm run bundle && npm run minify"
   },
   "engine": {


### PR DESCRIPTION
I tried to use your lib as a package but since you use es6 - uglify won't compile it. I added babel as a prepublish step so it is automatically converted before sending it to npm.